### PR TITLE
Updates site url for the open graph tags

### DIFF
--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -22,7 +22,7 @@
     <meta property="og:site_name" content="CarrierJs" />
     <meta
       property="og:url"
-      content="https://theritikchoure.github.io/carrierjs/doc/"
+      content="https://carrier.js.org/"
     />
     <meta
       property="og:description"
@@ -31,7 +31,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content="https://theritikchoure.github.io/carrierjs/doc/assets/images/Carrier.Js.png"
+      content="https://carrier.js.org/assets/images/Carrier.Js.png"
     />
 
     <!-- Google Font -->

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -15,17 +15,17 @@
 	<!-- Open Graph -->
 	<meta property="og:title" content="CarrierJs - Promise based HTTP client with ultimate caching">
 	<meta property="og:site_name" content="CarrierJs">
-	<meta property="og:url" content="https://theritikchoure.github.io/carrierjs/doc/docs.html">
+	<meta property="og:url" content="https://carrier.js.org/docs.html">
 	<meta property="og:description" content="Carrier JS is promise based http client for browsers. It is used to interact with servers with the ultimate caching feature. You can retrieve data from a URL without having to do a full page refresh.">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="https://theritikchoure.github.io/carrierjs/doc/assets/images/Carrier.Js.png">
+	<meta property="og:image" content="https://carrier.js.org/assets/images/Carrier.Js.png">
 	
 	<!-- Twitter Card -->
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="@carrier_js" />
 	<meta name="twitter:title" content="CarrierJs - Promise based HTTP client with ultimate caching" />
 	<meta name="twitter:description" content="Carrier JS is promise based http client for browsers. It is used to interact with servers with the ultimate caching feature. You can retrieve data from a URL without having to do a full page refresh." />
-	<meta name="twitter:image" content="https://theritikchoure.github.io/carrierjs/doc/assets/images/Carrier.Js.png" />
+	<meta name="twitter:image" content="https://carrier.js.org/assets/images/Carrier.Js.png" />
 
     <!-- Google Font -->
     <!-- <link href="https://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700&display=swap" rel="stylesheet"> -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,17 +14,17 @@
 	<!-- Open Graph -->
 	<meta property="og:title" content="CarrierJs - Promise based HTTP client with ultimate caching">
 	<meta property="og:site_name" content="CarrierJs">
-	<meta property="og:url" content="https://theritikchoure.github.io/carrierjs/doc/">
+	<meta property="og:url" content="https://carrier.js.org/">
 	<meta property="og:description" content="Carrier JS is promise based http client for browsers. It is used to interact with servers with the ultimate caching feature. You can retrieve data from a URL without having to do a full page refresh.">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="https://theritikchoure.github.io/carrierjs/doc/assets/images/Carrier.Js.png">
+	<meta property="og:image" content="https://carrier.js.org/assets/images/Carrier.Js.png">
 	<!-- Twitter Card -->
 	
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="@carrier_js" />
 	<meta name="twitter:title" content="CarrierJs - Promise based HTTP client with ultimate caching" />
 	<meta name="twitter:description" content="Carrier JS is promise based http client for browsers. It is used to interact with servers with the ultimate caching feature. You can retrieve data from a URL without having to do a full page refresh." />
-	<meta name="twitter:image" content="https://theritikchoure.github.io/carrierjs/doc/assets/images/Carrier.Js.png" />
+	<meta name="twitter:image" content="https://carrier.js.org/assets/images/Carrier.Js.png" />
 
     <!-- Google Font -->
     <!-- <link href="https://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700&display=swap" rel="stylesheet"> -->


### PR DESCRIPTION
Updates #5 

## Proposed Changes

  - Changes the open graph URLs to match the new domain name `carrier.js.org` in three HTML files.