### PR TITLE
feat: add new "timeout"  request option

### DIFF
--- a/carrier.js
+++ b/carrier.js
@@ -152,6 +152,10 @@ let carrier = {
                     handleOptions.setRequestHeader(req, options.headers);
                 }
 
+                if (options.timeout) {
+                    req.timeout = options.timeout;
+                }
+
                 req.send();
 
                 req.onload = async () => {
@@ -205,6 +209,10 @@ let carrier = {
                 handleOptions.setRequestHeader(req, options.headers);
             }
 
+            if (options.timeout) {
+                req.timeout = options.timeout;
+            }
+
             req.send(JSON.stringify(data) || null);
 
             req.onload = () => {
@@ -244,6 +252,10 @@ let carrier = {
 
             if(options.headers) {
                 handleOptions.setRequestHeader(req, options.headers);
+            }
+
+            if (options.timeout) {
+                req.timeout = options.timeout;
             }
 
             req.send(JSON.stringify(data) || null);
@@ -286,6 +298,10 @@ let carrier = {
                 handleOptions.setRequestHeader(req, options.headers);
             }
 
+            if (options.timeout) {
+                req.timeout = options.timeout;
+            }
+
             req.send(JSON.stringify(data) || null);
 
             req.onload = () => {
@@ -324,6 +340,10 @@ let carrier = {
             
             if(options.headers) {
                 handleOptions.setRequestHeader(req, options.headers);
+            }
+
+            if (options.timeout) {
+                req.timeout = options.timeout;
             }
 
             req.send(JSON.stringify(data) || null);


### PR DESCRIPTION
Add a new **timeout** request option

### Example Code:

```js
const options = {
    timeout:1000, // time in milliseconds
    headers: {
        'Content-Type': 'application/json'
    }
}

carrier.get('https://jsonplaceholder.typicode.com/todos/1',true,options).then((res) => {
    console.log(res);
}).catch((err) => {
    console.log(err);
});
```